### PR TITLE
Clarified prompts to fix attempted reading of wrong log file

### DIFF
--- a/SourceEngineConsoleParser/Program.cs
+++ b/SourceEngineConsoleParser/Program.cs
@@ -56,6 +56,7 @@ namespace SourceEngineConsoleParser
             fs = new FileStream(gameDir + "out.log", FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite);
 
             sReader = new StreamReader(fs);
+            logger.Write(sReader.ReadLine(), Logger.LogLevel.Success);
             bool readAll = true;
             while (true)
             {
@@ -105,7 +106,7 @@ namespace SourceEngineConsoleParser
                 if (gameDir.Length > 0 && gameDir[gameDir.Length - 1] != '\\' && gameDir[gameDir.Length - 1] != '/')
                     gameDir += "\\";
                 logger.WriteLine("", Logger.LogLevel.Nothing);
-                logger.Write("Please enter the subdirectory to the custom folder containing your autoexec. (eg tf\\custom\\customstuff\\) :  ", Logger.LogLevel.Info);
+                logger.Write("Please enter the subdirectory to the custom folder containing your autoexec. (eg custom\\customstuff\\) :  ", Logger.LogLevel.Info);
                 customPath = Console.ReadLine();
                 if (customPath.Length > 0 && customPath[customPath.Length - 1] != '\\' && customPath[customPath.Length - 1] != '/')
                     customPath += "\\";
@@ -116,7 +117,7 @@ namespace SourceEngineConsoleParser
                     customPath = customPath.Substring(1);
                 }
                 logger.WriteLine("", Logger.LogLevel.Nothing);
-                logger.Write("Please enter a key to use for executing commands (names for non-alphanumeric keys can be found on the wiki). Any existing bind for this key will be overwritten. :  ", Logger.LogLevel.Info);
+                logger.Write("Please enter a key to use for executing commands (names for non-alphanumeric keys can be found on the TF2 wiki). Any existing bind for this key will be overwritten. :  ", Logger.LogLevel.Info);
                 keyValue = Console.ReadLine();
                 logger.WriteLine("", Logger.LogLevel.Nothing);
                 Stream stream = File.Create("config.cfg");

--- a/SourceEngineConsoleParser/Program.cs
+++ b/SourceEngineConsoleParser/Program.cs
@@ -56,7 +56,6 @@ namespace SourceEngineConsoleParser
             fs = new FileStream(gameDir + "out.log", FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite);
 
             sReader = new StreamReader(fs);
-            logger.Write(sReader.ReadLine(), Logger.LogLevel.Success);
             bool readAll = true;
             while (true)
             {

--- a/SourceEngineConsoleParser/Program.cs
+++ b/SourceEngineConsoleParser/Program.cs
@@ -100,7 +100,7 @@ namespace SourceEngineConsoleParser
             if (runSetup)
             {
                 logger.ClearConsole();
-                logger.Write("Please enter path to Source game directory (eg C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Team Fortress 2\\) :  ",Logger.LogLevel.Info);
+                logger.Write("Please enter path to Source game directory (eg C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Team Fortress 2\\tf\\) :  ",Logger.LogLevel.Info);
                 gameDir = Console.ReadLine();
                 if (gameDir.Length > 0 && gameDir[gameDir.Length - 1] != '\\' && gameDir[gameDir.Length - 1] != '/')
                     gameDir += "\\";


### PR DESCRIPTION
The path being used to find the out.log file needs to include the /tf/, /csgo/, etc at the end of the path. Changed the prompts to tell the user this and ensure that the correct path is given.
